### PR TITLE
feat: added a threat tool to enable anonymous/private posts

### DIFF
--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -136,7 +136,7 @@ define('forum/category/tools', [
 		socket.on('event:topic_unlocked', setLockedState);
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
-        socket.on('event:topic_privated', setPrivatedState);
+		socket.on('event:topic_privated', setPrivatedState);
 		socket.on('event:topic_unprivated', setPrivatedState);
 		socket.on('event:topic_moved', onTopicMoved);
 	};
@@ -184,7 +184,7 @@ define('forum/category/tools', [
 		socket.removeListener('event:topic_unlocked', setLockedState);
 		socket.removeListener('event:topic_pinned', setPinnedState);
 		socket.removeListener('event:topic_unpinned', setPinnedState);
-        socket.removeListener('event:topic_privated', setPrivatedState);
+		socket.removeListener('event:topic_privated', setPrivatedState);
 		socket.removeListener('event:topic_unprivated', setPrivatedState);
 		socket.removeListener('event:topic_moved', onTopicMoved);
 	};
@@ -214,7 +214,7 @@ define('forum/category/tools', [
 		const isAnyDeleted = isAny(isTopicDeleted, tids);
 		const areAllDeleted = areAll(isTopicDeleted, tids);
 		const isAnyPinned = isAny(isTopicPinned, tids);
-        const isAnyPrivated = isAny(isTopicPrivated, tids);
+		const isAnyPrivated = isAny(isTopicPrivated, tids);
 		const isAnyLocked = isAny(isTopicLocked, tids);
 		const isAnyScheduled = isAny(isTopicScheduled, tids);
 		const areAllScheduled = areAll(isTopicScheduled, tids);
@@ -229,7 +229,7 @@ define('forum/category/tools', [
 		components.get('topic/pin').toggleClass('hidden', areAllScheduled || isAnyPinned);
 		components.get('topic/unpin').toggleClass('hidden', areAllScheduled || !isAnyPinned);
 
-        components.get('topic/private').toggleClass('hidden', isAnyPrivated);
+		components.get('topic/private').toggleClass('hidden', isAnyPrivated);
 		components.get('topic/unprivate').toggleClass('hidden', !isAnyPrivated);
 
 		components.get('topic/merge').toggleClass('hidden', isAnyScheduled);
@@ -265,7 +265,7 @@ define('forum/category/tools', [
 		return getTopicEl(tid).hasClass('pinned');
 	}
 
-    function isTopicPrivated(tid) {
+	function isTopicPrivated(tid) {
 		return getTopicEl(tid).hasClass('privated');
 	}
 
@@ -290,7 +290,7 @@ define('forum/category/tools', [
 		ajaxify.refresh();
 	}
 
-    function setPrivatedState(data) {
+	function setPrivatedState(data) {
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('privated', data.isPinned);
 		topic.find('[component="topic/privated"]').toggleClass('hidden', !data.isPrivated);

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -30,8 +30,8 @@ define('forum/topic/events', [
 		'event:topic_unpinned': threadTools.setPinnedState,
 
 		'event:topic_privated': threadTools.setPrivatedState,
-		'event:topic_unprivated': threadTools.setPrivatedState,	
-		
+		'event:topic_unprivated': threadTools.setPrivatedState,
+
 		'event:topic_moved': onTopicMoved,
 
 		'event:post_edited': onPostEdited,

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -57,14 +57,13 @@ define('forum/topic/threadTools', [
 		});
 
 		topicContainer.on('click', '[component="topic/private"]', function () {
-            console.log("HIT treadTools.js line 60");
-            topicCommand('put', '/private', 'private');
+			topicCommand('put', '/private', 'private');
 			return false;
-        });
-        topicContainer.on('click', '[component="topic/unprivate"]', function () {
-            topicCommand('del', '/private', 'private');
+		});
+		topicContainer.on('click', '[component="topic/unprivate"]', function () {
+			topicCommand('del', '/private', 'private');
 			return false;
-        });
+		});
 
 		topicContainer.on('click', '[component="topic/unpin"]', function () {
 			topicCommand('del', '/pin', 'unpin');
@@ -396,8 +395,7 @@ define('forum/topic/threadTools', [
 		const icon = $('[component="topic/labels"] [component="topic/privated"]');
 		icon.toggleClass('hidden', !data.private);
 		ajaxify.data.private = data.private;
-        data.events = data.events ? data.events : [];
-        console.log("EVENTS", JSON.stringify(data.events));
+		data.events = data.events ? data.events : [];
 		posts.addTopicEvents(data.events);
 	};
 

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -118,11 +118,11 @@ module.exports = function (Topics) {
 		return await togglePin(tid, uid, false);
 	};
 
-    topicTools.private = async function (tid, uid) {
+	topicTools.private = async function (tid, uid) {
 		return await togglePrivate(tid, uid, true);
 	};
 
-    topicTools.unprivate = async function (tid, uid) {
+	topicTools.unprivate = async function (tid, uid) {
 		return await togglePrivate(tid, uid, false);
 	};
 
@@ -157,7 +157,7 @@ module.exports = function (Topics) {
 		return tids.filter(Boolean);
 	};
 
-    async function togglePrivate(tid, uid, priv) {
+	async function togglePrivate(tid, uid, priv) {
 		const topicData = await Topics.getTopicData(tid);
 		if (!topicData) {
 			throw new Error('[[error:no-topic]]');


### PR DESCRIPTION
Added a thread tool to private and unprivate posts, allowing for posts to be hidden from users which aren't administrators or the original poster. Buttons were also added to the post settings dropdown menu. So far, only the frontend has been implemented fully, the backend still has some issues that need to be resolved (such as posts being marked private not being restored as such once the website is reloaded). Resolves #30 