### PR TITLE
feat: added Repost option to topic tools' tool menu. 

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/topic-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/topic-menu-list.tpl
@@ -20,6 +20,10 @@
 </li>
 
 <li>
+    <p><a component="topic/repost" href="#" id="new_repost" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-retweet text-secondary"></i> Repost</a></p>
+</li>
+
+<li>
 	<a component="topic/merge" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-code-fork text-secondary"></i> [[topic:thread-tools.merge]]</a>
 </li>
 

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -99,6 +99,18 @@ if (document.readyState === 'loading') {
 			app.newTopic();
 		});
 
+		$('body').on('click', '#new_repost', function (e) {
+			e.preventDefault();
+			var topicData = {
+				title: ajaxify.data.title,
+				body: null,
+			};
+			socket.emit('plugins.composer.push', ajaxify.data.mainPid, function (_, postData) {
+				topicData.body = '' + postData.body;
+				app.newTopic(topicData);
+			});
+		});
+
 		registerServiceWorker();
 
 		require([


### PR DESCRIPTION
The "Repost" button allows users to repost the topic to a different (or same) category. When the "Repost" button is clicked, it opens up the composer with the post data already filled out, so users can easily select a category to repost the topic to. 
Progress on issues: [#22](https://github.com/CMU-313/nodebb-s25-girasole/issues/22) [#23](https://github.com/CMU-313/nodebb-s25-girasole/issues/23)

Screenshots:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/6abb28dd-db32-43e8-8567-0f8702c01bce" />
<img width="581" alt="image" src="https://github.com/user-attachments/assets/c5216a36-e0f3-4326-b1d6-e7e044aca32c" />
