### PR TITLE
Feat: Add anonymous post and reply functionality

### DIFF
--- a/nodebb-plugin-anonymous/library.js
+++ b/nodebb-plugin-anonymous/library.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const hooks = require.main.require('./src/plugins/hooks');
+
+hooks.on('filter:composer.postData', async (hookData) => {
+  if (hookData.data && hookData.data.anonymous) {
+    console.log('[DEBUG] Anonymizing post data on server...');
+    // Override the user data to post anonymously
+    hookData.data.uid = 0;
+    hookData.data.username = 'Anonymous';
+    hookData.data.picture = '/assets/img/anonymous.png'; // Optional avatar
+  }
+  return hookData;
+});

--- a/nodebb-plugin-anonymous/library.js
+++ b/nodebb-plugin-anonymous/library.js
@@ -3,12 +3,12 @@
 const hooks = require.main.require('./src/plugins/hooks');
 
 hooks.on('filter:composer.postData', async (hookData) => {
-  if (hookData.data && hookData.data.anonymous) {
-    console.log('[DEBUG] Anonymizing post data on server...');
-    // Override the user data to post anonymously
-    hookData.data.uid = 0;
-    hookData.data.username = 'Anonymous';
-    hookData.data.picture = '/assets/img/anonymous.png'; // Optional avatar
-  }
-  return hookData;
+	if (hookData.data && hookData.data.anonymous) {
+		console.log('[DEBUG] Anonymizing post data on server...');
+		// Override the user data to post anonymously
+		hookData.data.uid = 0;
+		hookData.data.username = 'Anonymous';
+		hookData.data.picture = '/assets/img/anonymous.png'; // Optional avatar
+	}
+	return hookData;
 });

--- a/nodebb-plugin-anonymous/package.json
+++ b/nodebb-plugin-anonymous/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nodebb-plugin-anonymous",
+  "version": "1.0.0",
+  "description": "Plugin to enable anonymous posting in NodeBB",
+  "main": "library.js",
+  "engines": {
+    "node": ">=18",
+    "nodebb": ">=3.8.4"
+  },
+  "license": "GPL-3.0",
+  "nodebb": {
+    "isPlugin": true
+  }
+}

--- a/nodebb-theme-harmony/public/harmony.js
+++ b/nodebb-theme-harmony/public/harmony.js
@@ -290,30 +290,25 @@ document.addEventListener('click', function (event) {
 	// look for clicks on [component="topic/reply-anonymously"]
 	const el = event.target.closest('[component="topic/reply-anonymously"]');
 	if (!el) return;
-  
 	event.preventDefault();
 	console.log('[DEBUG] Anonymous reply button clicked!');
-  
 	// get the topic ID from ajaxify.data if on a topic page
 	const tid = ajaxify.data && ajaxify.data.tid;
 	if (!tid) {
-	  alert('No topic ID found!');
-	  return;
+		// alert('No topic ID found!');
+		return;
 	}
-  
 	// call a function that opens the composer with an anonymous flag
 	app.anonymousReply({ tid: tid });
-  });
-  
-  // define the function that sets up an "anonymous" composer
-  app.anonymousReply = async function (params) {
+});
+// define the function that sets up an "anonymous" composer
+app.anonymousReply = async function (params) {
 	if (typeof params !== 'object') {
-	  params = { tid: params };
+		params = { tid: params };
 	}
-	const [hooks, api] = await app.require(['hooks', 'api']);
-	params.title = ajaxify.data && ajaxify.data.titleRaw || 'Untitled';
+	const [hooks] = await app.require(['hooks', 'api']);
+	params.title = (ajaxify.data && ajaxify.data.titleRaw) || 'Untitled';
 	params.anonymous = true; // the important flag
-  
 	console.log('[DEBUG] Opening composer with anonymous = true', params);
 	hooks.fire('action:composer.post.new', params);
-  };
+};

--- a/nodebb-theme-harmony/public/harmony.js
+++ b/nodebb-theme-harmony/public/harmony.js
@@ -285,3 +285,35 @@ $(document).ready(function () {
 			.on('hidden.bs.dropdown', toggleOverflow);
 	}
 });
+
+document.addEventListener('click', function (event) {
+	// look for clicks on [component="topic/reply-anonymously"]
+	const el = event.target.closest('[component="topic/reply-anonymously"]');
+	if (!el) return;
+  
+	event.preventDefault();
+	console.log('[DEBUG] Anonymous reply button clicked!');
+  
+	// get the topic ID from ajaxify.data if on a topic page
+	const tid = ajaxify.data && ajaxify.data.tid;
+	if (!tid) {
+	  alert('No topic ID found!');
+	  return;
+	}
+  
+	// call a function that opens the composer with an anonymous flag
+	app.anonymousReply({ tid: tid });
+  });
+  
+  // define the function that sets up an "anonymous" composer
+  app.anonymousReply = async function (params) {
+	if (typeof params !== 'object') {
+	  params = { tid: params };
+	}
+	const [hooks, api] = await app.require(['hooks', 'api']);
+	params.title = ajaxify.data && ajaxify.data.titleRaw || 'Untitled';
+	params.anonymous = true; // the important flag
+  
+	console.log('[DEBUG] Opening composer with anonymous = true', params);
+	hooks.fire('action:composer.post.new', params);
+  };

--- a/nodebb-theme-harmony/templates/partials/topic-list-bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic-list-bar.tpl
@@ -38,7 +38,31 @@
 			<div class="d-flex gap-1 align-items-center">
 				{{{ if template.category }}}
 					{{{ if privileges.topics:create }}}
-					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
+					<div class="btn-group">
+						<!-- Main New Topic Button -->
+						<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">
+							[[category:new-topic-button]]
+						</a>
+
+						<!-- Dropdown Toggle Button -->
+						<button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+							<span class="caret"></span>
+						</button>
+
+						<!-- Dropdown Menu -->
+						<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
+							<li>
+								<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="dropdown-item" data-ajaxify="false" role="button">
+									Regular Topic
+								</a>
+							</li>
+							<li>
+								<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="dropdown-item" data-ajaxify="false" role="button">
+									Post Anonymously
+								</a>
+							</li>
+						</ul>
+					</div>
 					{{{ end }}}
 				{{{ else }}}
 					{{{ if canPost }}}

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -8,23 +8,33 @@
 <div class="d-flex align-items-start gap-3">
 	<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
 		<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+			{{{ if !posts.anonymous }}}
 			{buildAvatar(posts.user, "48px", true, "", "user/picture")}
 			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+			{{{ end }}}
 		</a>
 	</div>
+
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">
 			<meta itemprop="name" content="{./user.username}">
 			{{{ if ./user.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{./user.userslug}">{{{ end }}}
 
 			<div class="bg-body d-sm-none">
+				
 				<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
+				{{{ if !posts.anonymous }}}
 					{buildAvatar(posts.user, "20px", true, "", "user/picture")}
 					<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+				{{{ end }}}
 				</a>
 			</div>
 
-			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+			{{{ if posts.anonymous }}}
+			<span>ANONYMOUS</span>
+            {{{ else }}}
+            <a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+			{{{ end }}}
 
 			{{{ each posts.user.selectedGroups }}}
 			{{{ if posts.user.selectedGroups.slug }}}

--- a/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
@@ -1,27 +1,50 @@
 {{{ if privileges.topics:reply }}}
-<div component="topic/reply/container" class="btn-group">
-	<a href="{config.relative_path}/compose?tid={tid}" class="d-flex align-items-center btn btn-sm btn-primary px-3 fw-semibold" component="topic/reply" data-ajaxify="false" role="button"><i class="fa fa-reply d-sm-block d-md-none"></i><span class="d-none d-md-block"> [[topic:reply]]</span></a>
-	<button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="[[topic:reply-options]]">
-		<span class="caret"></span>
-	</button>
-	<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
-		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem">[[topic:reply-as-topic]]</a></li>
-	</ul>
-</div>
+  <!-- Anonymous Reply Button -->
+  <a href="#" class="d-flex align-items-center btn btn-sm btn-primary px-3 fw-semibold" 
+     component="topic/reply-anonymously" role="button">
+    <i class="fa fa-reply d-sm-block d-md-none"></i>
+    <span class="d-none d-md-block">Reply anonymously</span>
+  </a>
+
+  <!-- Regular Reply Buttons -->
+  <div component="topic/reply/container" class="btn-group">
+    <a href="{config.relative_path}/compose?tid={tid}" 
+       class="d-flex align-items-center btn btn-sm btn-primary px-3 fw-semibold" 
+       component="topic/reply" data-ajaxify="false" role="button">
+      <i class="fa fa-reply d-sm-block d-md-none"></i>
+      <span class="d-none d-md-block">[[topic:reply]]</span>
+    </a>
+    <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-bs-toggle="dropdown" 
+            aria-haspopup="true" aria-expanded="false" aria-label="[[topic:reply-options]]">
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
+      <li>
+        <a class="dropdown-item rounded-1" href="#" 
+           component="topic/reply-anonymously" role="menuitem">[[topic:reply-anonymously]]</a>
+      </li>
+    </ul>
+  </div>
 {{{ end }}}
 
 {{{ if loggedIn }}}
 	{{{ if !privileges.topics:reply }}}
 		{{{ if locked }}}
-		<a href="#" component="topic/reply/locked" class="d-flex gap-2 align-items-center fw-semibold btn btn-sm btn-primary disabled" disabled><i class="fa fa-lock"></i> [[topic:locked]]</a>
+		<a href="#" component="topic/reply/locked" class="d-flex gap-2 align-items-center fw-semibold btn btn-sm btn-primary disabled" disabled>
+      <i class="fa fa-lock"></i> [[topic:locked]]
+    </a>
 		{{{ end }}}
 	{{{ end }}}
 
 	{{{ if !locked }}}
-	<a href="#" component="topic/reply/locked" class="d-flex gap-2 align-items-center fw-semibold btn btn-sm btn-primary disabled hidden" disabled><i class="fa fa-lock"></i> [[topic:locked]]</a>
+	<a href="#" component="topic/reply/locked" class="d-flex gap-2 align-items-center fw-semibold btn btn-sm btn-primary disabled hidden" disabled>
+    <i class="fa fa-lock"></i> [[topic:locked]]
+  </a>
 	{{{ end }}}
 {{{ else }}}
 	{{{ if !privileges.topics:reply }}}
-	<a component="topic/reply/guest" href="{config.relative_path}/login" class="d-flex align-items-center fw-semibold btn btn-sm btn-primary">[[topic:guest-login-reply]]</a>
+	<a component="topic/reply/guest" href="{config.relative_path}/login" class="d-flex align-items-center fw-semibold btn btn-sm btn-primary">
+    [[topic:guest-login-reply]]
+  </a>
 	{{{ end }}}
 {{{ end }}}

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -15,6 +15,7 @@
 	"notify-me": "Be notified of new replies in this topic",
 	"quote": "Quote",
 	"reply": "Reply",
+	"reply-anonymously": "Reply Anonymously",
 	"replies-to-this-post": "%1 Replies",
 	"one-reply-to-this-post": "1 Reply",
 	"last-reply-time": "Last reply",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -17,6 +17,7 @@
     "last-reply-time": "Last reply",
     "reply-options": "Reply options",
     "reply-as-topic": "Reply as topic",
+    "reply-anonymously": "Reply anonymously",
     "guest-login-reply": "Log in to reply",
     "login-to-view": "🔒 Log in to view",
     "edit": "Edit",

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -63,6 +63,8 @@ get:
                           type: string
                         timestamp:
                           type: number
+                        anonymous:
+                          type: boolean 
                         votes:
                           type: number
                         deleted:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -64,6 +64,8 @@ get:
                     type: boolean
                   downvoted:
                     type: boolean
+                  anonymous:
+                    type: number
 put:
   tags:
     - posts

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -326,6 +326,32 @@ if (document.readyState === 'loading') {
 		hooks.fire('action:composer.post.new', params);
 	};
 
+	app.anonymousReply = async function (params) {
+		// For backwards compatibility, if someone calls app.anonymousReply(tid)
+		if (typeof params !== 'object') {
+		  console.warn('[deprecated] app.anonymousReply(tid) — please pass in an object');
+		  params = {
+			tid: params,
+		  };
+		}
+	  
+		// We need hooks and api
+		const [hooks, api] = await app.require(['hooks', 'api']);
+	  
+		// If we're on a topic page, we can use ajaxify.data.titleRaw.
+		// Otherwise, fetch the topic info from the server.
+		params.title = (ajaxify.data.template.topic ?
+		  ajaxify.data.titleRaw :
+		  (await api.get(`/topics/${params.tid}`)).titleRaw
+		);
+	  
+		// Mark this as an anonymous reply
+		params.anonymous = true;
+	  
+		// Fire the same composer hook as a normal reply, but with an 'anonymous' flag
+		hooks.fire('action:composer.post.new', params);
+	  };
+
 	app.loadJQueryUI = function (callback) {
 		if (typeof $().autocomplete === 'function') {
 			return callback();

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -329,29 +329,23 @@ if (document.readyState === 'loading') {
 	app.anonymousReply = async function (params) {
 		// For backwards compatibility, if someone calls app.anonymousReply(tid)
 		if (typeof params !== 'object') {
-		  console.warn('[deprecated] app.anonymousReply(tid) — please pass in an object');
-		  params = {
-			tid: params,
-		  };
+			console.warn('[deprecated] app.anonymousReply(tid) — please pass in an object');
+			params = {
+				tid: params,
+			};
 		}
-	  
 		// We need hooks and api
 		const [hooks, api] = await app.require(['hooks', 'api']);
-	  
 		// If we're on a topic page, we can use ajaxify.data.titleRaw.
 		// Otherwise, fetch the topic info from the server.
 		params.title = (ajaxify.data.template.topic ?
-		  ajaxify.data.titleRaw :
-		  (await api.get(`/topics/${params.tid}`)).titleRaw
+			ajaxify.data.titleRaw : (await api.get(`/topics/${params.tid}`)).titleRaw
 		);
-	  
 		// Mark this as an anonymous reply
 		params.anonymous = true;
-	  
 		// Fire the same composer hook as a normal reply, but with an 'anonymous' flag
 		hooks.fire('action:composer.post.new', params);
-	  };
-
+	};
 	app.loadJQueryUI = function (callback) {
 		if (typeof $().autocomplete === 'function') {
 			return callback();

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -115,6 +115,12 @@ define('forum/topic/postTools', [
 			e.preventDefault();
 			onReplyClicked($(this), tid);
 		});
+		
+		$('.topic').on('click', '[component="topic/replyAnonymously"]', function (e) {
+			e.preventDefault();
+			onAnonymousReplyClicked($(this), tid);
+		});
+
 
 		$('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
 			translator.translate(`[[topic:link-back, ${ajaxify.data.titleRaw}, ${config.relative_path}/topic/${ajaxify.data.slug}]]`, function (body) {
@@ -269,6 +275,7 @@ define('forum/topic/postTools', [
 	}
 
 	async function onReplyClicked(button, tid) {
+		console.log("reply clicked");
 		const selectedNode = await getSelectedNode();
 
 		showStaleWarning(async function () {
@@ -291,11 +298,50 @@ define('forum/topic/postTools', [
 					selectedPid: selectedNode.pid,
 				});
 			} else {
+				console.log("non anonymous about to post")
 				hooks.fire('action:composer.post.new', {
 					tid: tid,
 					pid: toPid,
 					title: ajaxify.data.titleRaw,
 					body: username ? username + ' ' : ($('[component="topic/quickreply/text"]').val() || ''),
+					anonymous: false
+				});
+			}
+		});
+	}
+
+	async function onAnonymousReplyClicked(button, tid) {
+		console.log("reply anonymously clicked");
+		const selectedNode = await getSelectedNode();
+
+		showStaleWarning(async function () {
+			console.log("entered showStaleWarning");
+			let username = await getUserSlug(button);
+			if (getData(button, 'data-uid') === '0' || !getData(button, 'data-userslug')) {
+				username = '';
+			}
+
+			const toPid = button.is('[component="post/reply"]') ? getData(button, 'data-pid') : null;
+			const isQuoteToPid = !toPid || !selectedNode.pid || toPid === selectedNode.pid;
+
+			if (selectedNode.text && isQuoteToPid) {
+				username = username || selectedNode.username;
+				hooks.fire('action:composer.addQuote', {
+					tid: tid,
+					pid: toPid,
+					title: ajaxify.data.titleRaw,
+					username: username,
+					body: selectedNode.text,
+					selectedPid: selectedNode.pid,
+				});
+			} else {
+				console.log("anonymous reply about to fire hook!");
+				hooks.fire('action:composer.post.new', {
+					tid: tid,
+					pid: toPid,
+					title: ajaxify.data.titleRaw,
+					body: username ? username + ' ' : ($('[component="topic/quickreply/text"]').val() || ''),
+					anonymous: true
 				});
 			}
 		});

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -115,7 +115,6 @@ define('forum/topic/postTools', [
 			e.preventDefault();
 			onReplyClicked($(this), tid);
 		});
-		
 		$('.topic').on('click', '[component="topic/replyAnonymously"]', function (e) {
 			e.preventDefault();
 			onAnonymousReplyClicked($(this), tid);
@@ -275,9 +274,8 @@ define('forum/topic/postTools', [
 	}
 
 	async function onReplyClicked(button, tid) {
-		console.log("reply clicked");
+		console.log('reply clicked');
 		const selectedNode = await getSelectedNode();
-
 		showStaleWarning(async function () {
 			let username = await getUserSlug(button);
 			if (getData(button, 'data-uid') === '0' || !getData(button, 'data-userslug')) {
@@ -298,24 +296,24 @@ define('forum/topic/postTools', [
 					selectedPid: selectedNode.pid,
 				});
 			} else {
-				console.log("non anonymous about to post")
+				console.log('non anonymous about to post');
 				hooks.fire('action:composer.post.new', {
 					tid: tid,
 					pid: toPid,
 					title: ajaxify.data.titleRaw,
 					body: username ? username + ' ' : ($('[component="topic/quickreply/text"]').val() || ''),
-					anonymous: false
+					anonymous: false,
 				});
 			}
 		});
 	}
 
 	async function onAnonymousReplyClicked(button, tid) {
-		console.log("reply anonymously clicked");
+		console.log('reply anonymously clicked');
 		const selectedNode = await getSelectedNode();
 
 		showStaleWarning(async function () {
-			console.log("entered showStaleWarning");
+			console.log('entered showStaleWarning');
 			let username = await getUserSlug(button);
 			if (getData(button, 'data-uid') === '0' || !getData(button, 'data-userslug')) {
 				username = '';
@@ -335,13 +333,13 @@ define('forum/topic/postTools', [
 					selectedPid: selectedNode.pid,
 				});
 			} else {
-				console.log("anonymous reply about to fire hook!");
+				console.log('anonymous reply about to fire hook!');
 				hooks.fire('action:composer.post.new', {
 					tid: tid,
 					pid: toPid,
 					title: ajaxify.data.titleRaw,
 					body: username ? username + ' ' : ($('[component="topic/quickreply/text"]').val() || ''),
-					anonymous: true
+					anonymous: true,
 				});
 			}
 		});

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -51,6 +51,13 @@ exports.post = async function (req, res) {
 	};
 	req.body.noscript = 'true';
 
+	// ANONYMOUS OVERRIDE: If anonymous flag is set, post as Anonymous
+	if (body.anonymous) {
+		data.uid = 0;
+		data.username = 'Anonymous';
+		data.picture = '/assets/img/anonymous.png';
+	  }
+
 	if (!data.content) {
 		return helpers.noScriptErrors(req, res, '[[error:invalid-data]]', 400);
 	}

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -56,7 +56,7 @@ exports.post = async function (req, res) {
 		data.uid = 0;
 		data.username = 'Anonymous';
 		data.picture = '/assets/img/anonymous.png';
-	  }
+	}
 
 	if (!data.content) {
 		return helpers.noScriptErrors(req, res, '[[error:invalid-data]]', 400);

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -35,6 +35,7 @@ module.exports = function (Posts) {
 			tid: tid,
 			content: content,
 			timestamp: timestamp,
+			anonymous: data.anonymous || false
 		};
 
 		if (data.toPid) {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -35,7 +35,7 @@ module.exports = function (Posts) {
 			tid: tid,
 			content: content,
 			timestamp: timestamp,
-			anonymous: data.anonymous || false
+			anonymous: Boolean(data.anonymous),
 		};
 
 		if (data.toPid) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,9 +7,8 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'anonymous'
+	'replies', 'bookmarks', 'anonymous',
 ];
-
 module.exports = function (Posts) {
 	Posts.getPostsFields = async function (pids, fields) {
 		if (!Array.isArray(pids) || !pids.length) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks',
+	'replies', 'bookmarks', 'anonymous'
 ];
 
 module.exports = function (Posts) {

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -167,7 +167,7 @@ module.exports = function (Topics) {
 		data = await plugins.hooks.fire('filter:topic.reply', data);
 		const { tid } = data;
 		const { uid } = data;
-		const { anonymous } = data;
+		const anonymous = !!data.anonymous;
 
 		const [topicData, isAdmin] = await Promise.all([
 			Topics.getTopicData(tid),
@@ -177,8 +177,7 @@ module.exports = function (Topics) {
 		await canReply(data, topicData);
 
 		data.cid = topicData.cid;
-		data.anonymous = anonymous || false;
-
+		data.anonymous = Boolean(anonymous);
 		await guestHandleValid(data);
 		data.content = String(data.content || '').trimEnd();
 

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -167,6 +167,7 @@ module.exports = function (Topics) {
 		data = await plugins.hooks.fire('filter:topic.reply', data);
 		const { tid } = data;
 		const { uid } = data;
+		const { anonymous } = data;
 
 		const [topicData, isAdmin] = await Promise.all([
 			Topics.getTopicData(tid),
@@ -176,6 +177,7 @@ module.exports = function (Topics) {
 		await canReply(data, topicData);
 
 		data.cid = topicData.cid;
+		data.anonymous = anonymous || false;
 
 		await guestHandleValid(data);
 		data.content = String(data.content || '').trimEnd();

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -131,7 +131,18 @@ module.exports = function (Topics) {
 
 		postData.forEach((postObj, i) => {
 			if (postObj) {
-				postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
+				if (postObj.anonymous) {
+					postObj.user = {
+						username: 'Anonymous',
+						displayname: 'Anonymous',
+						picture: 'assets/images/anonymous-avatar.png',
+						'icon:text': 'A',
+						'icon:bgColor': '#666'
+					};
+				} else {
+					postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
+				}
+
 				postObj.editor = postObj.editor ? editors[postObj.editor] : null;
 				postObj.bookmarked = bookmarks[i];
 				postObj.upvoted = voteData.upvotes[i];
@@ -139,12 +150,7 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-
-				// Username override for guests, if enabled
-				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
-					postObj.user.username = validator.escape(String(postObj.handle));
-					postObj.user.displayname = postObj.user.username;
-				}
+			
 			}
 		});
 

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -2,13 +2,13 @@
 'use strict';
 
 const _ = require('lodash');
-const validator = require('validator');
+// const validator = require('validator');
 const nconf = require('nconf');
 
 const db = require('../database');
 const user = require('../user');
 const posts = require('../posts');
-const meta = require('../meta');
+// const meta = require('../meta');
 const plugins = require('../plugins');
 const utils = require('../utils');
 
@@ -131,13 +131,14 @@ module.exports = function (Topics) {
 
 		postData.forEach((postObj, i) => {
 			if (postObj) {
+				postObj.anonymous = !!postObj.anonymous;
 				if (postObj.anonymous) {
 					postObj.user = {
 						username: 'Anonymous',
 						displayname: 'Anonymous',
 						picture: 'assets/images/anonymous-avatar.png',
 						'icon:text': 'A',
-						'icon:bgColor': '#666'
+						'icon:bgColor': '#666',
 					};
 				} else {
 					postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
@@ -150,10 +151,8 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-			
 			}
 		});
-
 		const result = await plugins.hooks.fire('filter:topics.addPostData', {
 			posts: postData,
 			uid: uid,


### PR DESCRIPTION
This PR implements the frontend UI for the anonymous post and reply feature. Users can now see two new buttons:
	•	Anonymous Post button, which opens a post dialogue.
<img width="1459" alt="Screenshot 2025-02-27 at 1 14 09 PM" src="https://github.com/user-attachments/assets/81184900-815b-4a30-bdd9-fe35e1ed59f0" />

	•	Anonymous Reply button, which opens a reply dialogue.
 
<img width="1390" alt="Screenshot 2025-02-27 at 1 14 36 PM" src="https://github.com/user-attachments/assets/f1b21cd8-8287-4414-b720-fbc8b49592e8" />


Although the backend logic to handle anonymous posting isn’t fully functional yet (the post still shows the name of the user), the UI successfully persists after a page refresh, ensuring a smoother user experience.

Changes Introduced
	•	Added buttons for anonymous posting and replying.
	•	Implemented modal dialogues for submitting anonymous posts and replies.
	•	Ensured that the buttons remain visible after a page refresh (handled state persistence).

Challenges & Limitations
	•	Currently, posts do not appear as anonymous due to a complex backend issue.
	•	I sought assistance from TAs, but the issue requires further debugging.
	•	The next step is to resolve backend integration to ensure anonymity works correctly.

Next Steps
	•	Investigate and fix the backend issue preventing anonymous posts from appearing correctly.
	•	Test and validate the entire flow from UI to backend once the issue is resolved.