### PR TITLE
feat: Thumbnail sizes and private posts

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -146,6 +146,8 @@ paths:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
+  /topics/{tid}/private:
+    $ref: 'write/topics/tid/private.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
   /topics/{tid}/ignore:

--- a/public/openapi/write/topics/tid/private.yaml
+++ b/public/openapi/write/topics/tid/private.yaml
@@ -1,0 +1,63 @@
+put:
+  tags:
+    - topics
+  summary: private a topic
+  description: This operation privates an existing topic.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            expiry:
+              type: number
+              description: A UNIX timestamp representing the moment the topic will be unpinned.
+              example: 1585337827953
+  responses:
+    '200':
+      description: Topic successfully privated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - topics
+  summary: unprivate a topic
+  description: This operation unprivates a topic.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully unprivated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/test/api.js
+++ b/test/api.js
@@ -375,17 +375,27 @@ describe('API', async () => {
 		paths.forEach((pathObj) => {
 			describe(`${pathObj.method.toUpperCase()} ${pathObj.path}`, () => {
 				it('should private a topic successfully', async () => {
+					if (pathObj.path !== '/topics/{tid}' || pathObj.method.toLowerCase() !== 'put') {
+						return;
+					}
+
 					const topicId = '1';
 					const payload = { expiry: 1585337827953 };
-				
-					const response = await request(app)
-					  .put(`/topics/${topicId}`)
-					  .send(payload)
-					  .set('Accept', 'application/json');
-				
-					expect(response.statusCode).toBe(200);
-					expect(response.body).toHaveProperty('status');
-					expect(response.body).toHaveProperty('response');
+
+					const topicsUrl = `${nconf.get('url')}/topics/${topicId}`;
+
+					const response = await request.put(topicsUrl, {
+						jar: jar,
+						headers: {
+							Accept: 'application/json',
+							'x-csrf-token': csrfToken,
+						},
+						body: payload,
+					});
+
+					assert.strictEqual(response.response.statusCode, 200, 'Expected status code 200');
+					assert(response.body.hasOwnProperty('status'), 'Response should have property "status"');
+					assert(response.body.hasOwnProperty('response'), 'Response should have property "response"');
 				});
 
 				it('should be defined in schema docs', () => {

--- a/test/api.js
+++ b/test/api.js
@@ -374,6 +374,20 @@ describe('API', async () => {
 		// For each express path, query for existence in read and write api schemas
 		paths.forEach((pathObj) => {
 			describe(`${pathObj.method.toUpperCase()} ${pathObj.path}`, () => {
+				it('should private a topic successfully', async () => {
+					const topicId = '1';
+					const payload = { expiry: 1585337827953 };
+				
+					const response = await request(app)
+					  .put(`/topics/${topicId}`)
+					  .send(payload)
+					  .set('Accept', 'application/json');
+				
+					expect(response.statusCode).toBe(200);
+					expect(response.body).toHaveProperty('status');
+					expect(response.body).toHaveProperty('response');
+				});
+
 				it('should be defined in schema docs', () => {
 					let schema = readApi;
 					if (pathObj.path.startsWith('/api/v3')) {


### PR DESCRIPTION
This PR adds some tests for the new topics/private API added as part of the anonymous posts feature. The backend for the anonymous posts feature turned out to require a lot more effort than initially expected, due to issues with config.json that occurred when attempting to build the new changes and are difficult to debug. The feature cannot be completed within the two-week sprint timeframe.