### PR TITLE
feat: implemented backend api support for keyword-based search mechanism

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -238,6 +238,8 @@ paths:
     $ref: 'write/flags/flagId/notes/datetime.yaml'
   /search/categories:
     $ref: 'write/search/categories.yaml'
+  /search/topics:
+    $ref: 'write/search/topics.yaml'
   /search/chats/{roomId}/users:
     $ref: 'write/search/chats/roomId/users.yaml'
   /search/chats/{roomId}/messages:

--- a/public/openapi/write/search/topics.yaml
+++ b/public/openapi/write/search/topics.yaml
@@ -1,0 +1,46 @@
+get:
+  tags:
+    - search
+  summary: find topics by keyword
+  description:
+    This operation returns a set of topics matching the keyword search.
+
+    If post topics are already filtered through, they are passed in via the query.
+  parameters:
+    - in: query
+      name: 'keyword'
+      schema:
+        type: string
+      required: false
+      description: The keyword used in the topics search
+      example: 'welcome'
+    - in: query
+      name: 'initTopics'
+      schema:
+        type: array
+      required: false
+      description: A list of initial topics before the search was initiated according to the category, filters, etc.
+      example: '0'
+  responses:
+    '200':
+      description: matching topics successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  topics:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                          description: The topic title which contains the keyword
+    '400':
+      $ref: ../../components/responses/400.yaml#/400

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const db = require('../database');
 const user = require('../user');
 const categories = require('../categories');
+const topics = require('../topics');
 const messaging = require('../messaging');
 const privileges = require('../privileges');
 const meta = require('../meta');
@@ -106,6 +107,14 @@ async function loadCids(uid, parentCid) {
 	await getCidsRecursive(pageCids);
 	return resultCids;
 }
+
+searchApi.topics = async (caller, query) => {
+	const keyword = query.keyword || '';
+	const initTopics = query.initTopics || null;
+
+	const searchResults = await topics.searchByKeyword({ keyword, initTopics });
+	return searchResults;
+};
 
 searchApi.roomUsers = async (caller, { query, roomId }) => {
 	const [isAdmin, inRoom, isRoomOwner] = await Promise.all([

--- a/src/controllers/write/search.js
+++ b/src/controllers/write/search.js
@@ -9,6 +9,11 @@ Search.categories = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.search.categories(req, req.query));
 };
 
+Search.topics = async (req, res) => {
+	const { keyword, initTopics } = req.query;
+	helpers.formatApiResponse(200, res, await api.search.topics(req, { keyword, initTopics }));
+};
+
 Search.roomUsers = async (req, res) => {
 	const { query, uid } = req.query;
 	helpers.formatApiResponse(200, res, await api.search.roomUsers(req, { query, uid, ...req.params }));

--- a/src/routes/write/search.js
+++ b/src/routes/write/search.js
@@ -14,6 +14,7 @@ module.exports = function () {
 	// setupApiRoute(router, 'post', '/', [...middlewares], controllers.write.search.TBD);
 
 	setupApiRoute(router, 'get', '/categories', [], controllers.write.search.categories);
+	setupApiRoute(router, 'get', '/topics', [], controllers.write.search.topics);
 
 	setupApiRoute(router, 'get', '/chats/:roomId/users', [...middlewares, middleware.checkRequired.bind(null, ['query']), middleware.canChat, middleware.assert.room], controllers.write.search.roomUsers);
 	setupApiRoute(router, 'get', '/chats/:roomId/messages', [...middlewares, middleware.checkRequired.bind(null, ['query']), middleware.canChat, middleware.assert.room], controllers.write.search.roomMessages);

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -34,6 +34,7 @@ Topics.thumbs = require('./thumbs');
 require('./bookmarks')(Topics);
 require('./merge')(Topics);
 Topics.events = require('./events');
+require('./search')(Topics);
 
 Topics.exists = async function (tids) {
 	return await db.exists(

--- a/src/topics/search.js
+++ b/src/topics/search.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function (Topics) {
+	Topics.searchByKeyword = async function (query) {
+		const keyword = query.keyword || '';
+		const initTopics = query.initTopics || null;
+
+		if (initTopics) {
+			const topicsByKeyword = initTopics.filter((topic) => {
+				const title = topic.title.toLowerCase();
+				return title.includes(keyword);
+			});
+
+			const searchResult = { topics: topicsByKeyword };
+			return searchResult;
+		}
+
+		return { topics: initTopics };
+	};
+};

--- a/test/topics/search.js
+++ b/test/topics/search.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('assert');
+
+const categories = require('../../src/categories');
+const topics = require('../../src/topics');
+const user = require('../../src/user');
+
+describe('Topic Search', () => {
+	let fooUid;
+	let topic1;
+	let topic2;
+	let topic3;
+
+	before(async () => {
+		fooUid = await user.create({ username: 'foo', password: '123456' });
+
+		topic1 = await topics.post({
+			title: 'Welcome to NodeBB!',
+			content: 'We hope you have fun!',
+			uid: fooUid,
+			cid: 1,
+		});
+		topic2 = await topics.post({
+			title: 'Come to Office Hours today',
+			content: 'OH will be held in Gates from 3-4.',
+			uid: fooUid,
+			cid: 1,
+		});
+		topic3 = await topics.post({
+			title: 'When will homework be posted today?',
+			content: 'Just wondering what time homework will be posted.',
+			uid: fooUid,
+			cid: 1,
+		});
+	});
+
+	it('should return topics containing the keyword in the title', async () => {
+		const query = { keyword: 'come', initTopics: [topic1.topicData, topic2.topicData, topic3.topicData] };
+		const result = await topics.searchByKeyword(query);
+
+		assert.strictEqual(result.topics.length, 2);
+		assert.strictEqual(result.topics[0].title, 'Welcome to NodeBB!');
+		assert.strictEqual(result.topics[1].title, 'Come to Office Hours today');
+	});
+
+	it('should return empty array if no topic titles match the keyword', async () => {
+		const query = { keyword: 'x', initTopics: [topic1.topicData, topic2.topicData, topic3.topicData] };
+		const result = await topics.searchByKeyword(query);
+
+		assert.strictEqual(result.topics.length, 0);
+	});
+
+	it('should return empty array if there are no topics to search from', async () => {
+		const query = { keyword: 'come', initTopics: [] };
+		const result = await topics.searchByKeyword(query);
+
+		assert.strictEqual(result.topics.length, 0);
+	});
+
+	it('should return all topics if keyword is an empty string', async () => {
+		const query = { keyword: '', initTopics: [topic1.topicData, topic2.topicData, topic3.topicData] };
+		const result = await topics.searchByKeyword(query);
+
+		assert.strictEqual(result.topics.length, 3);
+		assert.strictEqual(result.topics[0].title, 'Welcome to NodeBB!');
+		assert.strictEqual(result.topics[1].title, 'Come to Office Hours today');
+		assert.strictEqual(result.topics[2].title, 'When will homework be posted today?');
+	});
+
+	it('should not handle search keywords using a case-sensitive approach', async () => {
+		const query = { keyword: 'nodebb', initTopics: [topic1.topicData, topic2.topicData, topic3.topicData] };
+		const result = await topics.searchByKeyword(query);
+
+		assert.strictEqual(result.topics.length, 1);
+		assert.strictEqual(result.topics[0].title, 'Welcome to NodeBB!');
+	});
+
+	it('should return topics containing partial keyword matches', async () => {
+		const query = { keyword: 'to', initTopics: [topic1.topicData, topic2.topicData, topic3.topicData] };
+		const result = await topics.searchByKeyword(query);
+
+		assert.strictEqual(result.topics.length, 3);
+		assert.strictEqual(result.topics[0].title, 'Welcome to NodeBB!');
+		assert.strictEqual(result.topics[1].title, 'Come to Office Hours today');
+		assert.strictEqual(result.topics[2].title, 'When will homework be posted today?');
+	});
+});


### PR DESCRIPTION
Implemented a backend change so that the search bar frontend feature (#34) is able to be used to enter a keyword and filter through posts in different categories and pages according to the topic. This is done through an API endpoint that filters through topic titles and keeps ones containing the keyword. The purpose of this is to allow users to search posts by topic based on keywords no matter the page or category they are searching through. Solves #28 

Searching 'hello'
<img width="1277" alt="Screenshot 2025-02-27 at 4 50 01 PM" src="https://github.com/user-attachments/assets/e127518e-cc2b-45ec-9472-e8c008985168" />

Searching 'nodebb'
<img width="1277" alt="Screenshot 2025-02-27 at 4 50 40 PM" src="https://github.com/user-attachments/assets/22073dea-c3f2-48b8-9fd7-180b7884e3ae" />

Seaching 'x' (no results)
<img width="1278" alt="Screenshot 2025-02-27 at 4 51 03 PM" src="https://github.com/user-attachments/assets/6e665deb-2d7d-45d4-8d1a-74207144ff82" />