### PR TITLE
Added ES Lint tool (not on starter list)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,9 @@
+import globals from "globals";
+import pluginJs from "@eslint/js";
+
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  {languageOptions: { globals: globals.browser }},
+  pluginJs.configs.recommended,
+];


### PR DESCRIPTION
Added the ES Lint tool to the repository, which can be used via the command npx eslint file.js, as shown in the screenshot below.

<img width="1512" alt="Screenshot 2025-03-11 at 8 10 40 PM" src="https://github.com/user-attachments/assets/9ac5c398-1bc6-4d4c-ae11-8e053d3816c9" />
